### PR TITLE
Add 1.0.2g release

### DIFF
--- a/1.0.207/OpenSSL.podspec.json
+++ b/1.0.207/OpenSSL.podspec.json
@@ -1,0 +1,36 @@
+{
+    "name": "OpenSSL",
+    "version": "1.0.207",
+    "summary": "OpenSSL is an SSL/TLS and Crypto toolkit. Deprecated in Mac OS and gone in iOS, this spec gives your project non-deprecated OpenSSL support.",
+    "authors": "OpenSSL Project <openssl-dev@openssl.org>",
+    "homepage": "https://github.com/FredericJacobs/OpenSSL-Pod",
+    "source": {
+        "http": "https://openssl.org/source/openssl-1.0.2g.tar.gz",
+        "sha1": "36af23887402a5ea4ebef91df8e61654906f58f2"
+    },
+    "source_files": "opensslIncludes/openssl/*.h",
+    "header_dir": "openssl",
+    "license": {
+        "type": "OpenSSL (OpenSSL/SSLeay)",
+        "file": "LICENSE"
+    },
+    "prepare_command": "VERSION=\"1.0.2g\"\nSDKVERSION=`xcrun --sdk iphoneos --show-sdk-version 2> /dev/null`\nMIN_SDK_VERSION_FLAG=\"-miphoneos-version-min=7.0\"\n\nBASEPATH=\"${PWD}\"\nCURRENTPATH=\"/tmp/openssl\"\nARCHS=\"i386 x86_64 armv7 armv7s arm64\"\nDEVELOPER=`xcode-select -print-path`\n\nmkdir -p \"${CURRENTPATH}\"\nmkdir -p \"${CURRENTPATH}/bin\"\n\ncp \"file.tgz\" \"${CURRENTPATH}/file.tgz\"\ncd \"${CURRENTPATH}\"\ntar -xzf file.tgz\ncd \"openssl-${VERSION}\"\n\nfor ARCH in ${ARCHS}\ndo\n  CONFIGURE_FOR=\"iphoneos-cross\"\n\n  if [ \"${ARCH}\" == \"i386\" ] || [ \"${ARCH}\" == \"x86_64\" ] ;\n  then\n    PLATFORM=\"iPhoneSimulator\"\n    if [ \"${ARCH}\" == \"x86_64\" ] ;\n    then\n      CONFIGURE_FOR=\"darwin64-x86_64-cc\"\n    fi\n  else\n    sed -ie \"s!static volatile sig_atomic_t intr_signal;!static volatile intr_signal;!\" \"crypto/ui/ui_openssl.c\"\n    PLATFORM=\"iPhoneOS\"\n  fi\n\n  export CROSS_TOP=\"${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer\"\n  export CROSS_SDK=\"${PLATFORM}${SDKVERSION}.sdk\"\n\n  echo \"Building openssl-${VERSION} for ${PLATFORM} ${SDKVERSION} ${ARCH}\"\n  echo \"Please stand by...\"\n\n  export CC=\"${DEVELOPER}/usr/bin/gcc -arch ${ARCH} ${MIN_SDK_VERSION_FLAG}\"\n  mkdir -p \"${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk\"\n  LOG=\"${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk/build-openssl-${VERSION}.log\"\n\n  LIPO_LIBSSL=\"${LIPO_LIBSSL} ${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk/lib/libssl.a\"\n  LIPO_LIBCRYPTO=\"${LIPO_LIBCRYPTO} ${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk/lib/libcrypto.a\"\n\n  ./Configure ${CONFIGURE_FOR} --openssldir=\"${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk\" > \"${LOG}\" 2>&1\n  sed -ie \"s!^CFLAG=!CFLAG=-isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} !\" \"Makefile\"\n\n  make >> \"${LOG}\" 2>&1\n  make all install_sw >> \"${LOG}\" 2>&1\n  make clean >> \"${LOG}\" 2>&1\ndone\n\n\necho \"Build library...\"\nrm -rf \"${BASEPATH}/lib/\"\nmkdir -p \"${BASEPATH}/lib/\"\nlipo -create ${LIPO_LIBSSL}    -output \"${BASEPATH}/lib/libssl.a\"\nlipo -create ${LIPO_LIBCRYPTO} -output \"${BASEPATH}/lib/libcrypto.a\"\n\necho \"Copying headers...\"\nrm -rf \"${BASEPATH}/opensslIncludes/\"\nmkdir -p \"${BASEPATH}/opensslIncludes/\"\ncp -RL \"${CURRENTPATH}/openssl-${VERSION}/include/openssl\" \"${BASEPATH}/opensslIncludes/\"\n\ncd \"${BASEPATH}\"\necho \"Building done.\"\n\necho \"Cleaning up...\"\nrm -rf \"${CURRENTPATH}\"\necho \"Done.\"",
+    "ios": {
+        "public_header_files": "opensslIncludes/openssl/*.h",
+        "vendored_libraries": [
+            "lib/libcrypto.a",
+            "lib/libssl.a"
+        ]
+    },
+    "libraries": [
+        "crypto",
+        "ssl"
+    ],
+    "requires_arc": false,
+    "platforms": {
+        "osx": null,
+        "ios": null,
+        "tvos": null,
+        "watchos": null
+    }
+}


### PR DESCRIPTION
The previous pod (1.0.206) was broken by the release of [1.0.2g](https://www.openssl.org/news/secadv/20160301.txt), which invalidated the tarball link to 1.0.2f.

This PR adds the latest 1.0.2g release as 1.0.207, and seems to pass local validation via `pod spec lint`.

On a side note would you consider having the Podspecs to point to github tag releases [here](https://github.com/openssl/openssl/releases), or some other stable tarball link? Thanks!